### PR TITLE
Add the ability to deploy to production on Now (Vercel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "export": "routify export",
     "build:docker": "npm run build && ./scripts/docker/docker-build.sh",
     "deploy:now": "cd scripts/now && npm run deploy",
+    "deploy:now:prod": "cd scripts/now && npm run deploy:prod",
     "deploy:netlify": "cd scripts/netlify && npm run deploy",
     "rollup": "rollup -cw",
     "routify": "routify -D"

--- a/scripts/now/package.json
+++ b/scripts/now/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "build": "echo \"dummy build\"",
     "build:app": "cd ../.. && npm run build",
-    "deploy": "node build && npx now"
+    "deploy": "node build && npx now",
+    "deploy:prod": "node build && npx now --prod"
   },
   "dependencies": {
     "@sveltech/ssr": "^0.0.9",


### PR DESCRIPTION
By running `npm run deploy:now:prod`, you can deploy to production. This can keep your production and test version separate.