### PR TITLE
add HMR, & Nollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 .DS_Store
 **/.history
+/src/tmp/

--- a/.nolluprc.js
+++ b/.nolluprc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hot: true,
+  contentBase: 'static',
+  publicPath: 'build',
+  proxy: {
+    '/': 'http://localhost:5000',
+  },
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "run-p routify rollup",
+    "dev:nollup": "run-p routify nollup",
     "dev-dynamic": "cross-env BUNDLING=dynamic npm run dev",
     "build": "routify -bD && rollup -c",
     "serve": "spassr --serve-spa --serve-ssr",
@@ -11,10 +12,11 @@
     "deploy:now": "cd scripts/now && npm run deploy",
     "deploy:netlify": "cd scripts/netlify && npm run deploy",
     "rollup": "rollup -cw",
-    "routify": "routify -D"
+    "nollup": "nollup -c",
+    "routify": "routify -D -r src/tmp"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "concurrently": "^5.1.0",
     "cross-env": "^7.0.2",
@@ -24,10 +26,10 @@
     "ppid-changed": "^1.0.1",
     "rollup": "^2.6.1",
     "rollup-plugin-copy": "^3.3.0",
-    "rollup-plugin-hot": "^0.0.28",
+    "rollup-plugin-hot": "^0.0.30",
     "rollup-plugin-livereload": "^1.2.0",
     "rollup-plugin-svelte": "^5.2.1",
-    "rollup-plugin-svelte-hot": "^0.9.1",
+    "rollup-plugin-svelte-hot": "^0.9.2",
     "rollup-plugin-terser": "^5.3.0",
     "spassr": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "concurrently": "^5.1.0",
     "cross-env": "^7.0.2",
     "del": "^5.1.0",
-    "nollup": "rixo/nollup#next",
+    "nollup": "PepsRyuu/nollup#Refactor",
     "npm-run-all": "^4.1.5",
     "ppid-changed": "^1.0.1",
     "rollup": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -14,19 +14,22 @@
     "routify": "routify -D"
   },
   "devDependencies": {
-    "cross-env": "^7.0.2",
-    "@rollup/plugin-node-resolve": "^7.1.3",
     "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-node-resolve": "^7.1.3",
     "concurrently": "^5.1.0",
+    "cross-env": "^7.0.2",
     "del": "^5.1.0",
+    "nollup": "rixo/nollup#next",
     "npm-run-all": "^4.1.5",
     "ppid-changed": "^1.0.1",
-    "spassr": "^1.0.2",
     "rollup": "^2.6.1",
     "rollup-plugin-copy": "^3.3.0",
+    "rollup-plugin-hot": "^0.0.28",
     "rollup-plugin-livereload": "^1.2.0",
     "rollup-plugin-svelte": "^5.2.1",
-    "rollup-plugin-terser": "^5.3.0"
+    "rollup-plugin-svelte-hot": "^0.9.1",
+    "rollup-plugin-terser": "^5.3.0",
+    "spassr": "^1.0.2"
   },
   "dependencies": {
     "@sveltech/routify": "^1.5.9",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -114,20 +114,6 @@ const nollupConfig = {
 	plugins: [
 		// we want the serve
 		...bundledConfig.plugins,
-		{
-			// NOTE Nollup currently chokes on `export const {tree, routes} = ...`
-			name: 'hotfix for nollup',
-			transform(code, id) {
-				if (id.endsWith('/tmp/routes.js')) {
-					code = code.replace(
-						'export const {tree, routes} = buildClientTree(_tree)',
-						'       const {tree, routes} = buildClientTree(_tree); export {routes, tree}'
-					)
-					return { code }
-				}
-				return null
-			}
-		}
 	]
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
-import svelte from 'rollup-plugin-svelte';
+import svelte from 'rollup-plugin-svelte-hot';
+import Hmr from 'rollup-plugin-hot'
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
@@ -17,6 +18,13 @@ const shouldPrerender = (typeof process.env.PRERENDER !== 'undefined') ? process
 
 
 del.sync(distDir + '/**')
+
+const hot = !production
+
+const hmr = hot && Hmr({
+	inMemory: true,
+	public: 'static',
+})
 
 function createConfig({ output, inlineDynamicImports, plugins = [] }) {
   const transform = inlineDynamicImports ? bundledTransform : dynamicTransform
@@ -46,7 +54,8 @@ function createConfig({ output, inlineDynamicImports, plugins = [] }) {
         // a separate file — better for performance
         css: css => {
           css.write(`${buildDir}/bundle.css`);
-        }
+        },
+				hot,
       }),
 
       // If you have external dependencies installed from
@@ -65,7 +74,9 @@ function createConfig({ output, inlineDynamicImports, plugins = [] }) {
       // instead of npm run dev), minify
       production && terser(),
 
-      ...plugins
+      ...plugins,
+
+			hmr,
     ],
     watch: {
       clearScreen: false
@@ -82,7 +93,7 @@ const bundledConfig = {
   },
   plugins: [
     !production && serve(),
-    !production && livereload(distDir)
+    // !production && livereload(distDir)
   ]
 }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <script>
   import { Router } from "@sveltech/routify";
-  import { routes } from "@sveltech/routify/tmp/routes";
+  import { routes } from "./tmp/routes";
 </script>
 
 <Router {routes} />

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,6 @@
-// import HMR from  '@sveltech/routify/hmr'
-import App from './App.svelte';
+import HMR from '@sveltech/routify/hmr'
+import App from './App.svelte'
 
-const app = new App({ target: document.body })
+const app = HMR(App, { target: document.body }, 'routify-app')
 
-// const app = HMR(App, { target: document.body }, 'routify-app')
-//
-// export default app;
+export default app

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
-import HMR from  '@sveltech/routify/hmr'
+// import HMR from  '@sveltech/routify/hmr'
 import App from './App.svelte';
 
-const app = HMR(App, { target: document.body }, 'routify-app')
+const app = new App({ target: document.body })
 
-export default app;
+// const app = HMR(App, { target: document.body }, 'routify-app')
+//
+// export default app;


### PR DESCRIPTION
Add HMR, supported both with `rollup-plugin-hot` (`yarn dev`) or Nollup (`yarn dev:nollup`).

This is pretty experimental.

The Nollup support is provided by a patched branch in a fork because there are still bugs & blockers in currently published Nollup. They are being worked on currently -- the big fixes in my branch comes from a candidate "next" branch in the official repo.

Opening this PR for discussion, and information, if someone's searching for this.