### PR TITLE
fix serviceworker paths

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -76,7 +76,7 @@ export default {
             globDirectory: assetsDir,
             globPatterns: ['**/*.{js,css,svg}', '__app.html'],
             swSrc: `src/sw.js`,
-            swDest: `assets/build/serviceworker.js`,
+            swDest: `dist/serviceworker.js`,
             maximumFileSizeToCacheInBytes: 10000000, // 10 MB,
             mode: 'production'
         }),

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ export default app;
 
 // if ('serviceWorker' in navigator) {
 //     import('workbox-window').then(async ({ Workbox }) => {
-//         const wb = new Workbox('/build/serviceworker.js')
+//         const wb = new Workbox('/serviceworker.js')
 //         const registration = await wb.register()
 //         wb.addEventListener('installed', () => (console.log('installed service worker')))
 //         wb.addEventListener('externalinstalled', () => (console.log('installed service worker')))  


### PR DESCRIPTION
Copy `serviceworker.js` into `/dist/` instead of `/assets/build/` in order to fix its scope.