### PR TITLE
PWA: Service worker component update

### DIFF
--- a/src/Serviceworker.svelte
+++ b/src/Serviceworker.svelte
@@ -6,7 +6,7 @@
    */
   if ("serviceWorker" in navigator) {
     import("workbox-window").then(async ({ Workbox }) => {
-      const wb = new Workbox("/sw.js");
+      const wb = new Workbox("/serviceworker.js");
       const registration = await wb.register();
 
       // Reload the page if the PWA has been updated. Change strategy if needed.


### PR DESCRIPTION
I found out that the serviceworker.svelte can't be imported due to the name starting with lowercase. After changing it to uppercase, it worked as I would expect, and can use it as <Serviceworker/> component which will trigger the PWA Service worker.
Also, inside the component, the name of the script file was written as "sw.js", whereas after the build process, the output file is "serviceworker.js".

**Summary**
1. Renamed serviceworker.svelte to Serviceworker.svelte (to allow importing as a component)
2. Renamed the path of "sw.js"  to "serviceworker.js", following the output from rollup.config.js which outputs _serviceworker.js_