### PR TITLE
PWA logo maskable

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -14,7 +14,8 @@
     {
       "src": "/images/touch-icons/logo-800.png",
       "sizes": "800x800",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable any"
     }
   ]
 }


### PR DESCRIPTION
Added
"purpose": "maskable any"
to the PWA logo, which is  recommended by Google Chrome lighthouse PWA Guidelines.
Ref: [Google Dev reference](https://web.dev/maskable-icon-audit/)