### PR TITLE
Replace all instances of process.env.NODE_ENV

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,7 +75,7 @@ export default {
         {
             // provide node environment on the client
             transform: code => ({
-                code: code.replace('process.env.NODE_ENV', `"${process.env.NODE_ENV}"`),
+                code: code.replace(/process\.env\.NODE_ENV/g, `"${process.env.NODE_ENV}"`),
                 map: { mappings: '' }
             })
         },


### PR DESCRIPTION
Prevent `ReferenceError: process is not defined` error if `process.env.NODE_ENV` is referenced more than once within the project.