### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get started run:
 ```sh
 mkdir routify-app
 cd routify-app
-npx @roxi/routify init
+npm init routify
 ```
 
 


### PR DESCRIPTION
As 'npx @roxi/routify init' is deprecated so, replacing the line with 'npm init routify'.